### PR TITLE
implement RIP 7560 Bundler basic features

### DIFF
--- a/internal/start/rip7560.go
+++ b/internal/start/rip7560.go
@@ -127,6 +127,7 @@ func Rip7560Mode() {
 	// Init Client
 	c := rip7560client.New(mem, ov, chain, conf.SupportedEntryPoints, conf.OpLookupLimit)
 	c.SetGetUserOpReceiptFunc(rip7560client.GetUserOpReceiptWithEthClient(eth))
+	c.SetGetRip7560UserOpReceiptFunc(rip7560client.GetRip7560UserOpReceiptWithEthClient(eth))
 	c.SetGetGasPricesFunc(rip7560client.GetGasPricesWithEthClient(eth))
 	c.SetGetGasEstimateFunc(
 		rip7560client.GetGasEstimateWithEthClient(

--- a/pkg/entrypoint/filter/receipt.go
+++ b/pkg/entrypoint/filter/receipt.go
@@ -3,6 +3,7 @@ package filter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -98,4 +99,38 @@ func GetUserOperationReceipt(
 	}
 
 	return nil, nil
+}
+
+func GetRip7560UserOperationReceipt(
+	eth *ethclient.Client,
+	txHash common.Hash,
+	blkRange uint64) (*types.Receipt, error) {
+
+	header, err := eth.HeaderByNumber(context.Background(), nil)
+	if err != nil {
+
+		return nil, fmt.Errorf("failed to retrieve latest block header: %v", err)
+	}
+
+	latestBlock := header.Number
+	startBlock := new(big.Int).Sub(latestBlock, new(big.Int).SetUint64(blkRange))
+
+	for blockNumber := new(big.Int).Set(startBlock); blockNumber.Cmp(latestBlock) <= 0; blockNumber.Add(blockNumber, big.NewInt(1)) {
+		block, err := eth.BlockByNumber(context.Background(), blockNumber)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve block %v: %v", blockNumber, err)
+		}
+
+		for _, tx := range block.Transactions() {
+			if tx.Hash() == txHash {
+				receipt, err := eth.TransactionReceipt(context.Background(), txHash)
+				if err != nil {
+					return nil, fmt.Errorf("failed to retrieve transaction receipt: %v", err)
+				}
+
+				return receipt, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("transaction not found in the specified block range")
 }

--- a/pkg/modules/relay/relayer.go
+++ b/pkg/modules/relay/relayer.go
@@ -71,12 +71,12 @@ func (r *Relayer) SendUserOperationRip7560() modules.BatchHandlerFunc {
 	expectedRevenue := new(big.Int).SetUint64(0)
 	bundlerId := "1"
 	return func(ctx *modules.BatchHandlerCtx) error {
-		transactionArgs := r.buildTransactionArgs(ctx.Batch)
+		transactionArgs := r.BuildTransactionArgs(ctx.Batch)
 		return r.sendTransactionBundle(transactionArgs, creationBlock, expectedRevenue, bundlerId)
 	}
 }
 
-func (r *Relayer) buildTransactionArgs(batch []*userop.UserOperation) []rip7560client.UserOperationArgs {
+func (r *Relayer) BuildTransactionArgs(batch []*userop.UserOperation) []rip7560client.UserOperationArgs {
 	var transactionArgs []rip7560client.UserOperationArgs
 	for _, userOp := range batch {
 		txArgs := rip7560client.CreateUserOperationArgs(userOp)

--- a/pkg/rip7560client/client.go
+++ b/pkg/rip7560client/client.go
@@ -4,9 +4,11 @@ package rip7560client
 import (
 	"errors"
 	"math/big"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/go-logr/logr"
 	"github.com/stackup-wallet/stackup-bundler/internal/logger"
 	"github.com/stackup-wallet/stackup-bundler/pkg/entrypoint/filter"
@@ -22,18 +24,19 @@ import (
 // Client controls the end to end process of adding incoming UserOperations to the mempool. It also
 // implements the required RPC methods as specified in EIP-4337.
 type Client struct {
-	mempool              *mempool.Mempool
-	ov                   *gas.Overhead
-	chainID              *big.Int
-	supportedEntryPoints []common.Address
-	userOpHandler        modules.UserOpHandlerFunc
-	logger               logr.Logger
-	getUserOpReceipt     GetUserOpReceiptFunc
-	getGasPrices         GetGasPricesFunc
-	getGasEstimate       GetGasEstimateFunc
-	getUserOpByHash      GetUserOpByHashFunc
-	getStakeFunc         stake.GetStakeFunc
-	opLookupLimit        uint64
+	mempool                 *mempool.Mempool
+	ov                      *gas.Overhead
+	chainID                 *big.Int
+	supportedEntryPoints    []common.Address
+	userOpHandler           modules.UserOpHandlerFunc
+	logger                  logr.Logger
+	getUserOpReceipt        GetUserOpReceiptFunc
+	getRip7560UserOpReceipt GetRip7560UserOpReceiptFunc
+	getGasPrices            GetGasPricesFunc
+	getGasEstimate          GetGasEstimateFunc
+	getUserOpByHash         GetUserOpByHashFunc
+	getStakeFunc            stake.GetStakeFunc
+	opLookupLimit           uint64
 }
 
 // New initializes a new ERC-4337 client which can be extended with modules for validating UserOperations
@@ -46,18 +49,19 @@ func New(
 	opLookupLimit uint64,
 ) *Client {
 	return &Client{
-		mempool:              mempool,
-		ov:                   ov,
-		chainID:              chainID,
-		supportedEntryPoints: supportedEntryPoints,
-		userOpHandler:        noop.UserOpHandler,
-		logger:               logger.NewZeroLogr().WithName("client"),
-		getUserOpReceipt:     getUserOpReceiptNoop(),
-		getGasPrices:         getGasPricesNoop(),
-		getGasEstimate:       getGasEstimateNoop(),
-		getUserOpByHash:      getUserOpByHashNoop(),
-		getStakeFunc:         stake.GetStakeFuncNoop(),
-		opLookupLimit:        opLookupLimit,
+		mempool:                 mempool,
+		ov:                      ov,
+		chainID:                 chainID,
+		supportedEntryPoints:    supportedEntryPoints,
+		userOpHandler:           noop.UserOpHandler,
+		logger:                  logger.NewZeroLogr().WithName("client"),
+		getUserOpReceipt:        getUserOpReceiptNoop(),
+		getRip7560UserOpReceipt: getRip7560UserOpReceiptNoop(),
+		getGasPrices:            getGasPricesNoop(),
+		getGasEstimate:          getGasEstimateNoop(),
+		getUserOpByHash:         getUserOpByHashNoop(),
+		getStakeFunc:            stake.GetStakeFuncNoop(),
+		opLookupLimit:           opLookupLimit,
 	}
 }
 
@@ -85,6 +89,12 @@ func (i *Client) UseModules(handlers ...modules.UserOpHandlerFunc) {
 // EntryPoint address. This function is called in *Client.GetUserOperationReceipt.
 func (i *Client) SetGetUserOpReceiptFunc(fn GetUserOpReceiptFunc) {
 	i.getUserOpReceipt = fn
+}
+
+// SetGetUserOpRip7560ReceiptFunc defines a general function for fetching a UserOpReceipt given a userOpHash and
+// EntryPoint address. This function is called in *Client.GetUserOperationReceipt.
+func (i *Client) SetGetRip7560UserOpReceiptFunc(fn GetRip7560UserOpReceiptFunc) {
+	i.getRip7560UserOpReceipt = fn
 }
 
 // SetGetGasPricesFunc defines a general function for fetching values for maxFeePerGas and
@@ -118,27 +128,21 @@ func (i *Client) SetGetStakeFunc(fn stake.GetStakeFunc) {
 func (i *Client) SendUserOperation(op map[string]any, ep string) (string, error) {
 	// Init logger
 	l := i.logger.WithName("eth_sendUserOperation")
-
-	// Check EntryPoint and userOp is valid.
-	// [RIP-7560] not use entrypoint
-	//epAddr, err := i.parseEntryPointAddress(ep)
-	//if err != nil {
-	//	l.Error(err, "eth_sendUserOperation error")
-	//	return "", err
-	//}
 	epAddr := common.Address{}
-
-	l = l.
-		WithValues("entrypoint", epAddr.String()).
-		WithValues("chain_id", i.chainID.String())
+	l = l.WithValues("chain_id", i.chainID.String())
 
 	userOp, err := userop.New(op)
 	if err != nil {
 		l.Error(err, "eth_sendUserOperation error")
 		return "", err
 	}
-	hash := userOp.GetUserOpHash(epAddr, i.chainID)
-	l = l.WithValues("userop_hash", hash)
+
+	txHash, err := getTransactionHashByUserOp(op)
+	if err != nil {
+		l.Error(err, "getTransactionHashByUserOp error")
+		return "", err
+	}
+	l = l.WithValues("txHash", txHash)
 
 	// Run through client module stack.
 	ctx, err := modules.NewUserOpHandlerContext(
@@ -164,7 +168,7 @@ func (i *Client) SendUserOperation(op map[string]any, ep string) (string, error)
 	}
 
 	l.Info("eth_sendUserOperation ok")
-	return hash.String(), nil
+	return txHash.Hex(), nil
 }
 
 // EstimateUserOperationGas returns estimates for PreVerificationGas, VerificationGasLimit, and CallGasLimit
@@ -260,6 +264,29 @@ func (i *Client) GetUserOperationReceipt(
 	return ev, nil
 }
 
+// GetRIP7560UserOperationReceipt returns RIP7560 transaction receipt based on a userOp
+// *Client.SendUserOperation.
+func (i *Client) GetRIP7560UserOperationReceipt(
+	op userOperation,
+) (*types.Receipt, error) {
+	// Init logger
+	l := i.logger.WithName("eth_getUserOperationRip7560Receipt").WithValues("rip7560userop")
+
+	txHash, err := getTransactionHashByUserOp(op)
+	if err != nil {
+		l.Error(err, "getTransactionHashByUserOp error")
+		return nil, err
+	}
+
+	receipt, err := i.getRip7560UserOpReceipt(txHash, i.opLookupLimit)
+	if err != nil {
+		l.Error(err, "getRip7560UserOpReceipt error")
+	}
+
+	l.Info("eth_getUserOperationReceipt ok")
+	return receipt, nil
+}
+
 // GetUserOperationByHash returns a UserOperation based on a given userOpHash returned by
 // *Client.SendUserOperation.
 func (i *Client) GetUserOperationByHash(hash string) (*filter.HashLookupResult, error) {
@@ -291,4 +318,46 @@ func (i *Client) SupportedEntryPoints() ([]string, error) {
 // This method is used to validate that the client's chainID is in sync with the caller.
 func (i *Client) ChainID() (string, error) {
 	return hexutil.EncodeBig(i.chainID), nil
+}
+
+func getTransactionHashByUserOp(op userOperation) (common.Hash, error) {
+	userOp, err := userop.New(op)
+	if err != nil {
+		//l.Error(err, "eth_sendUserOperation error")
+		return common.Hash{}, err
+	}
+
+	txArgs := CreateUserOperationArgs(userOp)
+	gas, _ := strconv.ParseUint(txArgs.Gas[2:], 16, 64)
+	subType, _ := strconv.ParseUint(txArgs.SubType[2:], 16, 64)
+	sender := common.HexToAddress(txArgs.Sender)
+	builderFee, _ := new(big.Int).SetString(txArgs.BuilderFee, 0)
+	validationGas, _ := strconv.ParseUint(txArgs.ValidationGas[2:], 16, 64)
+	paymasterGas, _ := strconv.ParseUint(txArgs.PaymasterGas[2:], 16, 64)
+	postopGas, _ := strconv.ParseUint(txArgs.PostOpGas[2:], 16, 64)
+	bigNonce, _ := new(big.Int).SetString(txArgs.BigNonce, 0)
+	aatx := types.Rip7560AccountAbstractionTx{
+		Subtype:    subType,
+		To:         &common.Address{},
+		ChainID:    nil,
+		Gas:        gas,
+		GasTipCap:  userOp.MaxPriorityFeePerGas,
+		GasFeeCap:  userOp.MaxFeePerGas,
+		Value:      nil,
+		Data:       userOp.CallData,
+		AccessList: types.AccessList{},
+		// RIP-7560 parameters
+		Sender:        &sender,
+		Signature:     userOp.Signature,
+		PaymasterData: userOp.PaymasterAndData,
+		DeployerData:  userOp.InitCode,
+		BuilderFee:    builderFee,
+		ValidationGas: validationGas,
+		PaymasterGas:  paymasterGas,
+		PostOpGas:     postopGas,
+		// RIP-7712 parameter
+		BigNonce: bigNonce,
+	}
+	tx := types.NewTx(&aatx)
+	return tx.Hash(), nil
 }

--- a/pkg/rip7560client/rpc.go
+++ b/pkg/rip7560client/rpc.go
@@ -2,6 +2,7 @@ package rip7560client
 
 import (
 	"errors"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/stackup-wallet/stackup-bundler/pkg/entrypoint/filter"
 	"github.com/stackup-wallet/stackup-bundler/pkg/gas"
@@ -40,9 +41,9 @@ func (r *RpcAdapter) Eth_estimateUserOperationGas(
 
 // Eth_getUserOperationReceipt routes method calls to *Client.GetUserOperationReceipt.
 func (r *RpcAdapter) Eth_getUserOperationReceipt(
-	userOpHash string,
-) (*filter.UserOperationReceipt, error) {
-	return r.client.GetUserOperationReceipt(userOpHash)
+	op userOperation,
+) (*types.Receipt, error) {
+	return r.client.GetRIP7560UserOperationReceipt(op)
 }
 
 // Eth_getUserOperationByHash routes method calls to *Client.GetUserOperationByHash.

--- a/pkg/rip7560client/utils.go
+++ b/pkg/rip7560client/utils.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stackup-wallet/stackup-bundler/pkg/entrypoint/filter"
@@ -16,9 +17,16 @@ import (
 // GetUserOpReceiptFunc is a general interface for fetching a UserOperationReceipt given a userOpHash,
 // EntryPoint address, and block range.
 type GetUserOpReceiptFunc = func(hash string, ep common.Address, blkRange uint64) (*filter.UserOperationReceipt, error)
+type GetRip7560UserOpReceiptFunc = func(txHash common.Hash, blkRange uint64) (*types.Receipt, error)
 
 func getUserOpReceiptNoop() GetUserOpReceiptFunc {
 	return func(hash string, ep common.Address, blkRange uint64) (*filter.UserOperationReceipt, error) {
+		return nil, nil
+	}
+}
+
+func getRip7560UserOpReceiptNoop() GetRip7560UserOpReceiptFunc {
+	return func(txHash common.Hash, blkRange uint64) (*types.Receipt, error) {
 		return nil, nil
 	}
 }
@@ -28,6 +36,14 @@ func getUserOpReceiptNoop() GetUserOpReceiptFunc {
 func GetUserOpReceiptWithEthClient(eth *ethclient.Client) GetUserOpReceiptFunc {
 	return func(hash string, ep common.Address, blkRange uint64) (*filter.UserOperationReceipt, error) {
 		return filter.GetUserOperationReceipt(eth, hash, ep, blkRange)
+	}
+}
+
+// GetRip7560UserOpReceiptWithEthClient returns an implementation of GetRip7560UserOpReceiptFunc that relies on an eth
+// client to fetch a UserOperationReceipt.
+func GetRip7560UserOpReceiptWithEthClient(eth *ethclient.Client) GetRip7560UserOpReceiptFunc {
+	return func(txHash common.Hash, blkRange uint64) (*types.Receipt, error) {
+		return filter.GetRip7560UserOperationReceipt(eth, txHash, blkRange)
 	}
 }
 


### PR DESCRIPTION
# Description

Implement rip-7560 bundler APIs. Currently can use below set.
- eth_sendUserOperation
- eth_getUserOperationReceipt

Example relative bodies used in API call are as follows:
eth_sendUserOperation
```
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "eth_sendUserOperation",
  "params": [
    {
      "sender": "0xe6a91510f7671ed4b9420b0f765984903712dfe8",
      "nonce": "0x10000000000000000", // big nonce
      "initCode": "0x7560000000000000000000000000000000000002775c300c",
      "callData": "0xb61d27f600000000000000000000000075600000000000000000000000000000000000030000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000",
      "callGasLimit": "0x7A120", // 2,000,000
      "verificationGasLimit": "0x7A120", // 500,000
      "preVerificationGas": "0x186A0", // 100,000 == builder fee
      "maxFeePerGas": "0x2", // 1,100,000,
      "maxPriorityFeePerGas": "0x1",
      "paymasterAndData": "0x7560000000000000000000000000000000000000",
      "signature": "0x00",
      "paymasterVerificationGasLimit" : "0x7A120", //500,000
      "paymasterPostOpGasLimit" : "0x7A120" //500,000
    },
    "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789" //entrypoint address
  ]
}
```

eth_getUserOperationReceipt
```
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "eth_getUserOperationReceipt",
  "params": [
    {
      "sender": "0xe6a91510f7671ed4b9420b0f765984903712dfe8",
      "nonce": "0x10000000000000000", // big nonce
      "initCode": "0x7560000000000000000000000000000000000002775c300c",
      "callData": "0xb61d27f600000000000000000000000075600000000000000000000000000000000000030000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000",
      "callGasLimit": "0x7A120", // 2,000,000
      "verificationGasLimit": "0x7A120", // 500,000
      "preVerificationGas": "0x186A0", // 100,000 == builder fee
      "maxFeePerGas": "0x2", // 1,100,000,
      "maxPriorityFeePerGas": "0x1",
      "paymasterAndData": "0x7560000000000000000000000000000000000000",
      "signature": "0x00",
      "paymasterVerificationGasLimit" : "0x7A120", //500,000
      "paymasterPostOpGasLimit" : "0x7A120" //500,000
    }

  ]
}
```